### PR TITLE
HOMS-223 Do not use custom images for PostgreSQL DB containers

### DIFF
--- a/docker-compose.dev.oracle.yml
+++ b/docker-compose.dev.oracle.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   db_activiti:
-    image: latera/postgres-activiti
+    image: postgres
     hostname: postgres-activiti
     container_name: postgres-activiti
     restart: always
@@ -16,7 +16,7 @@ services:
     networks:
       - custom_network
   db_homs:
-    image: latera/postgres-homs
+    image: postgres
     hostname: postgres-homs
     container_name: postgres-homs
     environment:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   db_activiti:
-    image: latera/postgres-activiti
+    image: postgres
     hostname: postgres-activiti
     container_name: postgres-activiti
     restart: always
@@ -16,7 +16,7 @@ services:
     networks:
       - custom_network
   db_homs:
-    image: latera/postgres-homs
+    image: postgres
     hostname: postgres-homs
     container_name: postgres-homs
     environment:

--- a/docker-compose.oracle.yml
+++ b/docker-compose.oracle.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   db_activiti:
-    image: latera/postgres-activiti
+    image: postgres
     hostname: postgres-activiti
     container_name: postgres-activiti
     restart: always
@@ -14,7 +14,7 @@ services:
     networks:
       - custom_network
   db_homs:
-    image: latera/postgres-homs
+    image: postgres
     hostname: postgres-homs
     container_name: postgres-homs
     environment:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   db_homs:
-    image: latera/postgres-homs
+    image: postgres
     hostname: postgres-homs
     container_name: postgres-homs
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   db_activiti:
-    image: latera/postgres-activiti
+    image: postgres
     hostname: postgres-activiti
     container_name: postgres-activiti
     restart: always
@@ -16,7 +16,7 @@ services:
     networks:
       - custom_network
   db_homs:
-    image: latera/postgres-homs
+    image: postgres
     hostname: postgres-homs
     container_name: postgres-homs
     environment:


### PR DESCRIPTION
Maybe we can remove this repos now:
- https://github.com/latera/postgres-activiti-docker
- https://github.com/latera/postgres-homs-docker

Maybe not ¯\\_(ツ)_/¯