### PR TITLE
HBW-294 Add HBW styles customization with CSS variables PoC

### DIFF
--- a/app/assets/stylesheets/framework_and_overrides.sass
+++ b/app/assets/stylesheets/framework_and_overrides.sass
@@ -106,7 +106,6 @@ main.container
       @include progress-bar-variant($btn-default-border)
       background-color: #f5f5f5
 
-
 div.orders-list
   tbody > tr.expired
     td

--- a/hbw/app/assets/stylesheets/hbw.sass
+++ b/hbw/app/assets/stylesheets/hbw.sass
@@ -5,16 +5,18 @@
 @import url("https://use.fontawesome.com/releases/v5.7.1/css/fontawesome.css")
 
 @import 'jquery.growl'
+@import 'hbw/variables'
+@import 'hbw/brand_variables'
 
 .hbw-styles
-  @import 'hbw/variables'
-
   @import 'bootstrap'
   @import 'bootswatch/flatly/bootswatch'
   @import 'select2_bootstrap3'
   @import 'bootstrap-datetimepicker'
 
   @import 'tooltip'
+
+  @import 'hbw/branding'
 
   .growl-message
     max-height: 90px
@@ -153,36 +155,6 @@
   .edit-order-button
     margin-top: 1em
 
-  .btn-default:hover:not(.disabled)
-    background-color: $btn-default-border
-    border-color: $btn-default-border
-    color: $body-bg
-
-  .btn-primary:hover:not(.disabled)
-    background-color: $btn-primary-border
-    border-color: $btn-primary-border
-    color: $body-bg
-
-  .btn-success:hover:not(.disabled)
-    background-color: $btn-success-border
-    border-color: $btn-success-border
-    color: $body-bg
-
-  .btn-info:hover:not(.disabled)
-    background-color: $btn-info-border
-    border-color: $btn-info-border
-    color: $body-bg
-
-  .btn-warning:hover:not(.disabled)
-    background-color: $btn-warning-border
-    border-color: $btn-warning-border
-    color: $body-bg
-
-  .btn-danger:hover:not(.disabled)
-    background-color: $btn-danger-border
-    border-color: $btn-danger-border
-    color: $body-bg
-
   .clear-both
     clear: both
 
@@ -208,24 +180,6 @@
     @include gradient-striped
     @include animation(progress-bar-stripes 2s linear infinite)
     color: white
-
-    &.btn-primary
-      @include progress-bar-variant($btn-primary-border)
-
-    &.btn-success
-      @include progress-bar-variant($btn-success-border)
-
-    &.btn-info
-      @include progress-bar-variant($btn-info-border)
-
-    &.btn-warning
-      @include progress-bar-variant($btn-warning-border)
-
-    &.btn-danger
-      @include progress-bar-variant($btn-danger-border)
-
-    &.btn-default
-      @include progress-bar-variant($btn-default-border)
 
   .hidden
     visibility: hidden

--- a/hbw/app/assets/stylesheets/hbw/brand_variables.sass
+++ b/hbw/app/assets/stylesheets/hbw/brand_variables.sass
@@ -1,0 +1,16 @@
+.hbw-styles
+  // common
+  --base-body-bg-color: #{$body-bg}
+
+  // buttons
+  --base-btn-padding: 10px 15px
+  --base-btn-border: 2px solid
+  --base-btn-border-radius: 4px
+
+  // button colors
+  --base-btn-default-color: #{$btn-default-color}
+  --base-btn-primary-color: #{$btn-primary-color}
+  --base-btn-danger-color: #{$btn-danger-color}
+  --base-btn-success-color: #{$btn-success-color}
+  --base-btn-info-color: #{$btn-info-color}
+  --base-btn-warning-color: #{$btn-warning-color}

--- a/hbw/app/assets/stylesheets/hbw/branding.sass
+++ b/hbw/app/assets/stylesheets/hbw/branding.sass
@@ -1,0 +1,18 @@
+$button-types: default primary danger info success warning
+
+.btn
+  padding: var(--btn-padding, var(--base-btn-padding))
+  border: var(--btn-border, var(--base-btn-border))
+  border-radius: var(--btn-border-radius, var(--base-btn-border-radius))
+
+  @each $type in $button-types
+    &.btn-#{$type}
+      color: var(--btn-#{$type}-color, var(--base-btn-#{$type}-color))
+      border-color: var(--btn-#{$type}-color, var(--base-btn-#{$type}-color))
+
+      &.disabled
+        @include progress-bar-variant(var(--btn-#{$type}-color, var(--base-btn-#{$type}-color)))
+
+      &:hover:not(.disabled)
+        color: var(--base-body-bg-color, var(--body-bg-color))
+        background-color: var(--btn-#{$type}-color, var(--base-btn-#{$type}-color))

--- a/hbw/app/assets/stylesheets/hbw/variables.sass
+++ b/hbw/app/assets/stylesheets/hbw/variables.sass
@@ -1,9 +1,7 @@
 @import 'bootstrap-sprockets'
 @import 'bootswatch/flatly/variables'
 
-$btn-default-bg: darken($btn-default-bg, 10%)
-
-$btn-default-border: $btn-default-bg
+$btn-default-border: darken($btn-default-bg, 10%)
 $btn-default-bg: transparent
 $btn-default-color: $btn-default-border
 

--- a/hbw/app/javascript/packs/hbw/components/form/submit_select.js.jsx
+++ b/hbw/app/javascript/packs/hbw/components/form/submit_select.js.jsx
@@ -55,7 +55,6 @@ modulejs.define('HBWFormSubmitSelect', ['React'], (React) => {
         className={cssClass}
         title={option.title}
         onClick={onClick}
-        href="#"
         disabled={disabled}>
         <i className={faClass} />
         {` ${option.name}`}


### PR DESCRIPTION
##  Description

We can't just get rid of bootswatch theme (it used in HOMS not HBW only), so I propose to overload customizable properties explicitly like I've done it here in `branding.sass` (notice: we **can** use sass-variables from theme).

I decided to try this thing with buttons. Now you can customize only one color for button type (I think it's quite straightforward and usable) but we can make it finer grained later.

## Example

In the host system we should set variables under HBW root element without `base` prefix and it will overload default values. For example this (warning button is hovered):
![image](https://user-images.githubusercontent.com/7077548/85562903-96ef2b80-b635-11ea-86ba-db07c7090f3f.png)

is the result of 
```
--btn-primary-color: #278acc;  // local blue
--btn-success-color: #46a546;  // local green
--btn-danger-color: #df6762;  // local red
--btn-padding: 5px 10px;
```

Default version looks like this:
![image](https://user-images.githubusercontent.com/7077548/85563168-d0c03200-b635-11ea-8061-8fa9e95abf59.png)
