### PR TITLE
HOMS-350 Add missing labels for inputs on search order form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+v2.5.0 [unreleased]
+-------------------
+### Features
+- [#493](https://github.com/latera/homs/pull/493) Add missing labels for inputs on search order form.
+
 v2.4.0 [2020-08-14]
 -------------------
 ### Features

--- a/app/assets/stylesheets/framework_and_overrides.sass
+++ b/app/assets/stylesheets/framework_and_overrides.sass
@@ -224,6 +224,17 @@ input
   a
     cursor: pointer
 
+.labeled-input
+  display: flex
+
+  .label-input
+    display: block !important
+
+  .search
+    align-self: flex-end
+    height: fit-content
+    margin-left: 5px
+
 #custom-field-filter-container
   margin-left: -30px
 

--- a/app/views/orders/_search_by.html.haml
+++ b/app/views/orders/_search_by.html.haml
@@ -1,5 +1,9 @@
 = form_tag(path, method: :get, class: 'form-inline') do
   .form-group
-    = label_tag field, t('.search'), class: 'sr-only'
-    = text_field_tag :value, field_value, placeholder: t(".#{field}"), class: 'form-control'
-    = submit_tag t('.search'), class: 'btn btn-primary'
+    .labeled-input
+      %div
+        = label_tag field, t(".#{field}"), class: 'label-input'
+        = text_field_tag :value, field_value, placeholder: t(".#{field}"), class: 'form-control'
+
+      .search
+        = submit_tag t('.search'), class: 'btn btn-primary'

--- a/spec/features/orders/list_orders_spec.rb
+++ b/spec/features/orders/list_orders_spec.rb
@@ -271,7 +271,7 @@ feature 'List orders', js: true do
 
   scenario 'with correct search by code' do
     tab('Search for an order').click
-    input_by_placeholder('Order code').set(vacation_request_order.code)
+    input_by_label('code').set(vacation_request_order.code)
 
     search_button_by_action('/orders/search_by/code').click
     wait_for_ajax
@@ -280,7 +280,7 @@ feature 'List orders', js: true do
 
   scenario 'with correct search by ext code' do
     tab('Search for an order').click
-    input_by_placeholder('Order external code').set(vacation_request_order.ext_code)
+    input_by_label('ext_code').set(vacation_request_order.ext_code)
 
     search_button_by_action('/orders/search_by/ext_code').click
     wait_for_ajax

--- a/spec/support/helpers/orders_helper.rb
+++ b/spec/support/helpers/orders_helper.rb
@@ -30,10 +30,6 @@ module Features
       page.all('a[data-toggle="tab"]').select{|x| x.text == text}.first
     end
 
-    def input_by_placeholder(placeholder)
-      page.find("input[placeholder='#{placeholder}']")
-    end
-
     def expect_widget_presence
       expect(page.find('#hbw-tasks-list-button').all('*')).not_to be_empty
     end


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/33573380/90605699-637ce780-e207-11ea-99d2-6efc7dee7ead.png)
