### PR TITLE
Correct docker-compose.yml name for with_oracle installation

### DIFF
--- a/WITH_ORACLE.md
+++ b/WITH_ORACLE.md
@@ -89,7 +89,7 @@ If you want to use Oracle as source for your HOMS instance.
 13. Run `docker-compose` with custom config:
 
     ```bash
-    docker-compose -f docker-compose.dev.yml up -d
+    docker-compose -f docker-compose.oracle.yml up -d
     ```
 
 14. You can login to [Camunda Admin inteface](http://localhost:8766/camunda) with credentials equal to `BPM_USER:BPM_PASSWORD` values from `.env` file (`user/changeme` if these variables aren't set).


### PR DESCRIPTION
Correct the name of "docker-compose.dev.yml" to the proper one "docker-compose.oracle.yml" in paragraph 13