### PR TITLE
Bump puma from 4.3.5 to 4.3.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,7 +278,7 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (4.0.5)
-    puma (4.3.5)
+    puma (4.3.6)
       nio4r (~> 2.0)
     rack (2.2.3)
     rack-proxy (0.6.5)


### PR DESCRIPTION
4.3.5 has a bug on mac os:
```
include the header <ctype.h> or explicitly provide a declaration for 'isspace' 
1 error generated.
```
Fixed in 4.3.6.
https://github.com/puma/puma/issues/2304