### PR TITLE
HOMS-310 Wrap long variable values ​​to a new line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 v2.7.0 [unreleased]
 -------------------
+### Bugfixes
+- [#597](https://github.com/latera/homs/pull/597) Wrap long variable values ​​to a new line.
+
 ### Features
 - [#583](https://github.com/latera/homs/pull/583) Add the output of errors for the availability of the Сamunda service to the widget.
 - [#562](https://github.com/latera/homs/pull/562) Bring in TypeScript into the project.

--- a/app/assets/stylesheets/framework_and_overrides.sass
+++ b/app/assets/stylesheets/framework_and_overrides.sass
@@ -41,6 +41,7 @@ main.container
   .value
     display: inline-block
     margin-left: .4em
+    word-break: break-all
 
 .table-nowrap
   th, td

--- a/app/views/orders/_data.html.haml
+++ b/app/views/orders/_data.html.haml
@@ -1,5 +1,5 @@
 .row
-  .col-xs-6
+  .col-xs-12
     - data.each_pair do |name, value|
       - field_def_hash = @order.field_def_hash(name)
       .row.attribute-row


### PR DESCRIPTION
HOMS-310 Wrap long variable values ​​to a new line.

**Screens**:
<details>
<summary>Before</summary>

![Снимок экрана 2021-09-01 в 10 14 48](https://user-images.githubusercontent.com/49768177/131628781-2ab784e5-e363-415a-a392-a76681f23b72.png)

</details>
<details>
<summary>After</summary>

![Снимок экрана 2021-09-01 в 10 33 13](https://user-images.githubusercontent.com/49768177/131631051-50c25c71-8ad4-4f1c-98ba-5d7ff462b2b0.png)

</details>
