### PR TITLE
HOMS-316 Remove the mask option validation from the string order field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ v2.7.0 [unreleased]
 - [#592](https://github.com/latera/homs/pull/592) Replace memcached with redis.
 - [#586](https://github.com/latera/homs/pull/586) Stub api container in tests with local api mock file and refactor tests.
 - [#594](https://github.com/latera/homs/pull/594) Get rid of Webpacker & build all assets with Webpack 5.
+- [#598](https://github.com/latera/homs/pull/598) Remove the mask option validation from the string order field.
 
 v2.6.13 [unreleased]
 -------------------

--- a/app/classes/custom_fields/data_types/string.rb
+++ b/app/classes/custom_fields/data_types/string.rb
@@ -12,7 +12,6 @@ module CustomFields
           options[:max_length] <= MAX_LENGTH ||
           add_max_length_error(:max_length, MAX_LENGTH)
         )
-        may_have_key?(:mask, in: options, as: ::String)
       end
 
       def validate_value(attribute_name, value)

--- a/spec/classes/custom_fields/data_types/string_spec.rb
+++ b/spec/classes/custom_fields/data_types/string_spec.rb
@@ -72,20 +72,6 @@ module CustomFields
         end
       end
 
-      # Allow mask to be defined
-      # Do not enforce value to fit the mask, as there are many
-      # ways to define a mask. Depends on UI plugin
-      context 'Mask in string definition' do
-        let(:options) do
-          {mask: '(999) 999-99-99'}
-        end
-
-        it_behaves_like 'a CustomFields::Base descendant' do
-          it_behaves_like 'valid'
-          it_behaves_like 'has no errors'
-        end
-      end
-
       # value validation
       context 'nil value validation' do
         let(:options) { {} }


### PR DESCRIPTION
HOMS-316 Remove the mask option validation from the string order field.
- Removed method call.
- Removed test.
