### PR TITLE
HBW-337 Use button_text field for fallback submit-select components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,21 @@ v2.7.0 [unreleased]
                 fa_class: ['fas', 'user']
                 bp_code: 'new_customer'
   ```
+- [#607](https://github.com/latera/homs/pull/607) Use `button_text` field for fallback submit-select components. 
 
--------------------
+  For submit-select buttons was added new field `button_text` which contain a fallback for text translation. The previous behavior has been changed: the fallback on `label` field has been replaced with the `button_text` key. The key for translations still stored in the `name` field. For example:
+  ```
+          - name: submitSelectButton
+            type: submit_select
+            css_class: col-xs-12
+            options:
+              - name: button1
+                button_text: Button 1
+                value: Button 1
+                css_class: btn btn-success btn-lg
+  ```
+
+
 ### Features
 - [#583](https://github.com/latera/homs/pull/583) Add the output of errors for the availability of the Сamunda service to the widget.
 - [#562](https://github.com/latera/homs/pull/562) Bring in TypeScript into the project.

--- a/hbw/app/javascript/packs/hbw/components/form/submit_select_button.js.tsx
+++ b/hbw/app/javascript/packs/hbw/components/form/submit_select_button.js.tsx
@@ -10,7 +10,8 @@ type Props = {
     fa_class?: string,
     label: string,
     name: string,
-    title?: string
+    title?: string,
+    button_text?: string
   },
   error: boolean,
   onClick: MouseEventHandler<HTMLButtonElement>,
@@ -38,7 +39,7 @@ const HBWSubmitSelectButton: React.FC<Props> = ({
   const cssClass = cx(params.css_class, { buttonDisabled });
   const faClass = cx(params.fa_class, { buttonDisabled });
 
-  const label = translateBP(`${task.process_key}.${task.key}.${params.name}`, {}, params.label);
+  const label = translateBP(`${task.process_key}.${task.key}.${params.name}`, {}, params.button_text);
   const buildButton = () => (
       <button
         type="submit"

--- a/spec/hbw/features/bp_form/disabled_fields_mock.yml
+++ b/spec/hbw/features/bp_form/disabled_fields_mock.yml
@@ -156,11 +156,11 @@ get:
                             $var == 0
                       options:
                         - name: button1
-                          label: Button 1
+                          button_text: Button 1
                           value: Button 1
                           css_class: btn btn-success btn-lg
                         - name: button2
-                          label: Button 2
+                          button_text: Button 2
                           value: Button 2
                           css_class: btn btn-danger btn-lg
                 - name: submitSelectToBeEnabledGroup
@@ -177,12 +177,12 @@ get:
                             $var == 1
                       options:
                         - name: button1
-                          label: Button 1
                           value: Button 1
+                          button_text: Button 1
                           css_class: btn btn-success btn-lg
                         - name: button2
-                          label: Button 2
                           value: Button 2
+                          button_text: Button 2
                           css_class: btn btn-danger btn-lg
                 - name: submitSelectButtonsToBeDisabledGroup
                   type: group
@@ -194,16 +194,16 @@ get:
                       css_class: col-xs-12
                       options:
                         - name: disabledButton
-                          label: Disabled button
                           value: Disabled button
+                          button_text: Disabled button
                           css_class: btn btn-success btn-lg
                           disable_if:
                             - variable: homsOrderDataZeroVariable
                               condition: >
                                 $var == 0
                         - name: enabledButton
-                          label: Enabled button
                           value: Enabled button
+                          button_text: Enabled button
                           css_class: btn btn-danger btn-lg
                           disable_if:
                             - variable: homsOrderDataZeroVariable

--- a/spec/hbw/features/bp_form/dynamic_conditions_by_select_table_mock.yml
+++ b/spec/hbw/features/bp_form/dynamic_conditions_by_select_table_mock.yml
@@ -248,11 +248,11 @@ get:
                             "$var" == "2"
                       options:
                         - name: button1
-                          label: Button 1
+                          button_text: Button 1
                           value: Button 1
                           css_class: btn btn-success btn-lg
                         - name: button2
-                          label: Button 2
+                          button_text: Button 2
                           value: Button 2
                           css_class: btn btn-danger btn-lg
                 - name: dependentSubmitSelectButtonsGroup
@@ -266,11 +266,11 @@ get:
                       label: Dependent submit_select buttons
                       options:
                         - name: neutralButton
-                          label: Neutral button
+                          button_text: Neutral button
                           value: Neutral button
                           css_class: btn btn-success btn-lg
                         - name: buttonToBeDisabled
-                          label: Button to be disabled
+                          button_text: Button to be disabled
                           value: Button to be disabled
                           css_class: btn btn-danger btn-lg
                           dynamic: true
@@ -279,8 +279,8 @@ get:
                               condition: >
                                 "$var" == "1"
                         - name: buttonToBeHidden
-                          label: Button to be hidden
                           value: Button to be hidden
+                          button_text: Button to be hidden
                           css_class: btn btn-danger btn-lg
                           dynamic: true
                           delete_if:

--- a/spec/hbw/features/bp_form/hidden_fields_mock.yml
+++ b/spec/hbw/features/bp_form/hidden_fields_mock.yml
@@ -204,11 +204,11 @@ get:
                         $var == 0
                   options:
                     - name: button1
-                      label: Button 1
+                      button_text: Button 1
                       value: Button 1
                       css_class: btn btn-success btn-lg
                     - name: button2
-                      label: Button 2
+                      button_text: Button 2
                       value: Button 2
                       css_class: btn btn-danger btn-lg
             - name: submitSelectToBeVisibleGroup
@@ -225,11 +225,11 @@ get:
                         $var == 1
                   options:
                     - name: button1
-                      label: Button 1
                       value: Button 1
+                      button_text: Button 1
                       css_class: btn btn-success btn-lg
                     - name: button2
-                      label: Button 2
+                      button_text: Button 2
                       value: Button 2
                       css_class: btn btn-danger btn-lg
             - name: submitSelectButtonsToBeHiddenGroup
@@ -242,6 +242,7 @@ get:
                   css_class: col-xs-12
                   options:
                     - name: hiddenButton
+                      button_text: Hidden button
                       label: Hidden button
                       value: Hidden button
                       css_class: btn btn-success btn-lg
@@ -250,6 +251,7 @@ get:
                           condition: >
                             $var == 0
                     - name: visibleButton
+                      button_text: Visible button
                       label: Visible button
                       value: Visible button
                       css_class: btn btn-danger btn-lg

--- a/spec/hbw/features/bp_form/translation_mock.yml
+++ b/spec/hbw/features/bp_form/translation_mock.yml
@@ -100,11 +100,9 @@ get:
               css_class: col-xs-12
               options:
               - name: submitSelectButton1
-                label: Button 1
                 value: Value_1
                 css_class: btn btn-success btn-lg
               - name: submitSelectButton2
-                label: Button 2
                 value: Value_2
                 css_class: btn btn-danger btn-lg
 

--- a/spec/hbw/features/bp_form/translation_spec.rb
+++ b/spec/hbw/features/bp_form/translation_spec.rb
@@ -78,8 +78,8 @@ feature 'BP form with existing russian translation', js: true do
       expect(page).to     have_content 'Group'
       expect(page).to     have_content 'File upload field'
       expect(page).to     have_content 'Checkbox field'
-      expect(page).to     have_content 'Button 1'
-      expect(page).to     have_content 'Button 2'
+      expect(page).to     have_content 'submitSelectButton1'
+      expect(page).to     have_content 'submitSelectButton2'
 
       expect(page).not_to have_content 'Тестирование переводов'
       expect(page).not_to have_content 'Форма для тестирования переводов'

--- a/spec/hbw/features/user_mock.yml
+++ b/spec/hbw/features/user_mock.yml
@@ -79,7 +79,6 @@ get:
               css_class: col-xs-12
               options:
               - name: doMagic
-                label: Do Magic!
                 value: Do Magic
                 css_class: btn btn-success btn-lg
               - name: undo
@@ -114,11 +113,9 @@ get:
               css_class: col-xs-12
               options:
               - name: doMagic
-                label: Do Magic!
                 value: Do Magic
                 css_class: btn btn-success btn-lg
               - name: undo
-                label: Undo
                 value: Canceled
                 css_class: btn btn-danger btn-lg
 


### PR DESCRIPTION
For submit doesn't exist any value for fallback in forms keys. And it's look like this 
https://github.com/latera/homs/blob/master/hbw/app/javascript/packs/hbw/components/form/submit.js.jsx#L43

So, what ideas for it? May be we should use just hardcoded string 'Submit' for fallback?