### PR TITLE
HBW-379 Add disable_if/delete_if for submit_select buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+v2.6.19 [unreleased]
+-------------------
+### Features
+- [#633](https://github.com/latera/homs/pull/633) Add disable_if/delete_if for submit_select buttons.
+
 v2.6.18 [2021-12-02]
 -------------------
 ### Features

--- a/hbw/app/javascript/packs/hbw/components/form/submit_select.js.jsx
+++ b/hbw/app/javascript/packs/hbw/components/form/submit_select.js.jsx
@@ -1,7 +1,8 @@
 import cx from 'classnames';
 import compose from 'shared/utils/compose';
-import { withCallbacks, withErrorBoundary } from 'shared/hoc';
+import { withCallbacks, withConditions, withErrorBoundary } from 'shared/hoc';
 import CancelProcessButton from './cancel_process_button.js';
+import SubmitSelectButton from './submit_select_button.js';
 
 modulejs.define('HBWFormSubmitSelect', ['React'], (React) => {
   class HBWFormSubmitSelect extends React.Component {
@@ -21,13 +22,13 @@ modulejs.define('HBWFormSubmitSelect', ['React'], (React) => {
 
     render () {
       const {
-        params, name, showSubmit, showCancelButton
+        params, name, showSubmit, showCancelButton, hidden
       } = this.props;
 
       const self = this;
       const buttons = params.options.map(option => self.buildButton(option));
 
-      return showSubmit
+      return showSubmit && !hidden
       && <div className={cx('col-xs-12', params.css_class)}>
           <div className="control-buttons">
             { showCancelButton && this.renderCancelButton() }
@@ -38,28 +39,30 @@ modulejs.define('HBWFormSubmitSelect', ['React'], (React) => {
     }
 
     buildButton = (option) => {
-      const disabled = this.props.disabled || this.props.formSubmitting;
-      const { task, env } = this.props;
-      const { error } = this.state;
+      const buttonParams = {
+        ...option,
+        variables: this.props.params.variables
+      };
+      const {
+        env,
+        formValues,
+        id,
+        task,
+        disabled,
+        formSubmitting
+      } = this.props;
 
-      const onClick = () => this.setState({ value: option.value });
-
-      const cssClass = cx(option.css_class, { disabled });
-      const faClass = cx(option.fa_class, { disabled });
-
-      const label = env.bpTranslator(`${task.process_key}.${task.key}.${option.name}`, {}, option.name);
-
-      return (
-        <button key={option.name}
-                type="submit"
-                className={cssClass}
-                title={option.title}
-                onClick={onClick}
-                disabled={error || disabled}>
-          <i className={faClass} />
-          {` ${label}`}
-        </button>
-      );
+      return <SubmitSelectButton
+        env={env}
+        key={buttonParams.name}
+        params={buttonParams}
+        error={this.state.error}
+        onClick={() => this.setState({ value: option.value })}
+        formValues={formValues}
+        id={id}
+        task={task}
+        submitSelectDisabled={disabled || formSubmitting}
+      />;
     };
 
     renderCancelButton = () => {
@@ -78,5 +81,5 @@ modulejs.define('HBWFormSubmitSelect', ['React'], (React) => {
     };
   }
 
-  return compose(withCallbacks, withErrorBoundary)(HBWFormSubmitSelect);
+  return compose(withCallbacks, withConditions, withErrorBoundary)(HBWFormSubmitSelect);
 });

--- a/hbw/app/javascript/packs/hbw/components/form/submit_select_button.js.jsx
+++ b/hbw/app/javascript/packs/hbw/components/form/submit_select_button.js.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import cx from 'classnames';
+import compose from 'shared/utils/compose';
+import { withConditions, withCallbacks } from 'shared/hoc';
+
+const HBWSubmitSelectButton = ({
+  env,
+  params,
+  error,
+  onClick,
+  task,
+  disabled,
+  hidden,
+  submitSelectDisabled
+}) => {
+  const buttonDisabled = submitSelectDisabled || disabled;
+
+  const cssClass = cx(params.css_class, { buttonDisabled });
+  const faClass = cx(params.fa_class, { buttonDisabled });
+
+  const label = env.bpTranslator(`${task.process_key}.${task.key}.${params.name}`, {}, params.label);
+  const buildButton = () => (
+      <button
+        type="submit"
+        className={cssClass}
+        title={params.title}
+        onClick={onClick}
+        disabled={error || buttonDisabled}
+      >
+        <i className={faClass} />
+        {label}
+      </button>
+  );
+
+  return !hidden ? buildButton() : null;
+};
+
+export default compose(withCallbacks, withConditions)(HBWSubmitSelectButton);

--- a/hbw/config/yml_api.test.camunda.yml
+++ b/hbw/config/yml_api.test.camunda.yml
@@ -368,6 +368,140 @@ get:
           delete_if:
             - variable: homsOrderDataZeroVariable
               condition: $var == 0
+        - name: submitSelectToBeDisabledGroup
+          type: group
+          label: submit_select to be disabled group
+          css_class: col-xs-12
+          fields:
+            - name: submitSelectToBeDisabled
+              type: submit_select
+              css_class: col-xs-12
+              disable_if:
+                - variable: homsOrderDataZeroVariable
+                  condition: >
+                    $var == 0
+              options:
+                - name: button1
+                  label: Button 1
+                  value: Button 1
+                  css_class: btn btn-success btn-lg
+                - name: button2
+                  label: Button 2
+                  value: Button 2
+                  css_class: btn btn-danger btn-lg
+        - name: submitSelectToBeEnabledGroup
+          type: group
+          label: submit_select to be enabled group
+          css_class: col-xs-12
+          fields:
+            - name: submitSelectToBeEnabled
+              type: submit_select
+              css_class: col-xs-12
+              disable_if:
+                - variable: homsOrderDataZeroVariable
+                  condition: >
+                    $var == 1
+              options:
+                - name: button1
+                  label: Button 1
+                  value: Button 1
+                  css_class: btn btn-success btn-lg
+                - name: button2
+                  label: Button 2
+                  value: Button 2
+                  css_class: btn btn-danger btn-lg
+        - name: submitSelectButtonsToBeDisabledGroup
+          type: group
+          label: submit_select buttons to be disabled group
+          css_class: col-xs-12
+          fields:
+            - name: submitSelectButtonsToBeDisabled
+              type: submit_select
+              css_class: col-xs-12
+              options:
+                - name: disabledButton
+                  label: Disabled button
+                  value: Disabled button
+                  css_class: btn btn-success btn-lg
+                  disable_if:
+                    - variable: homsOrderDataZeroVariable
+                      condition: >
+                        $var == 0
+                - name: enabledButton
+                  label: Enabled button
+                  value: Enabled button
+                  css_class: btn btn-danger btn-lg
+                  disable_if:
+                    - variable: homsOrderDataZeroVariable
+                      condition: >
+                        $var == 1
+        - name: submitSelectToBeHiddenGroup
+          type: group
+          label: submit_select to be hidden group
+          css_class: col-xs-12
+          fields:
+            - name: submitSelectToBeHidden
+              type: submit_select
+              css_class: col-xs-12
+              delete_if:
+                - variable: homsOrderDataZeroVariable
+                  condition: >
+                    $var == 0
+              options:
+                - name: button1
+                  label: Button 1
+                  value: Button 1
+                  css_class: btn btn-success btn-lg
+                - name: button2
+                  label: Button 2
+                  value: Button 2
+                  css_class: btn btn-danger btn-lg
+        - name: submitSelectToBeVisibleGroup
+          type: group
+          label: submit_select to be visible group
+          css_class: col-xs-12
+          fields:
+            - name: submitSelectToBeVisible
+              type: submit_select
+              css_class: col-xs-12
+              delete_if:
+                - variable: homsOrderDataZeroVariable
+                  condition: >
+                    $var == 1
+              options:
+                - name: button1
+                  label: Button 1
+                  value: Button 1
+                  css_class: btn btn-success btn-lg
+                - name: button2
+                  label: Button 2
+                  value: Button 2
+                  css_class: btn btn-danger btn-lg
+        - name: submitSelectButtonsToBeHiddenGroup
+          type: group
+          label: submit_select buttons to be hidden group
+          css_class: col-xs-12
+          fields:
+            - name: submitSelectButtonsToBeHidden
+              type: submit_select
+              css_class: col-xs-12
+              options:
+                - name: hiddenButton
+                  label: Hidden button
+                  value: Hidden button
+                  css_class: btn btn-success btn-lg
+                  delete_if:
+                    - variable: homsOrderDataZeroVariable
+                      condition: >
+                        $var == 0
+                - name: visibleButton
+                  label: Visible button
+                  value: Visible button
+                  css_class: btn btn-danger btn-lg
+                  delete_if:
+                    - variable: homsOrderDataZeroVariable
+                      condition: >
+                        $var == 1
 
   "task/53452/deployed-form":
     "": |

--- a/spec/hbw/features/bp_form/disabled_fields_spec.rb
+++ b/spec/hbw/features/bp_form/disabled_fields_spec.rb
@@ -44,4 +44,21 @@ feature 'Control fields on form', js: true do
   scenario 'for text' do
     expect(find_by_name('homsOrderDataSomeDisabledText').readonly?).to eq true
   end
+
+  scenario 'for submit_select' do
+    in_group_with_label('submit_select to be disabled group') do |group|
+      group.find_button('Button 1', disabled: true)
+      group.find_button('Button 2', disabled: true)
+    end
+
+    in_group_with_label('submit_select to be enabled group') do |group|
+      group.find_button('Button 1', disabled: false)
+      group.find_button('Button 2', disabled: false)
+    end
+
+    in_group_with_label('submit_select buttons to be disabled group') do |group|
+      group.find_button('Disabled button', disabled: true)
+      group.find_button('Enabled button',  disabled: false)
+    end
+  end
 end

--- a/spec/hbw/features/bp_form/hidden_fields_spec.rb
+++ b/spec/hbw/features/bp_form/hidden_fields_spec.rb
@@ -60,4 +60,21 @@ feature 'Control fields on form', js: true do
   scenario 'for text' do
     expect(page).not_to have_selector "[name='homsOrderDataSomeText']"
   end
+
+  scenario 'for submit_select' do
+    in_group_with_label('submit_select to be hidden group') do |group|
+      expect(group).not_to have_content 'Button 1'
+      expect(group).not_to have_content 'Button 2'
+    end
+
+    in_group_with_label('submit_select to be visible group') do |group|
+      expect(group).to have_content 'Button 1'
+      expect(group).to have_content 'Button 2'
+    end
+
+    in_group_with_label('submit_select buttons to be hidden group') do |group|
+      expect(group).not_to have_content 'Hidden button'
+      expect(group).to have_content 'Visible button'
+    end
+  end
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -8,6 +8,7 @@ require 'support/helpers/wait_for_ajax_helper'
 require 'support/helpers/bp_form_helper'
 require 'support/helpers/i18n_helper'
 require 'support/helpers/files_helper'
+require 'support/helpers/scopes_helper'
 
 FIXTURES_PATH = File.join(__FILE__, '..', '..', '..', 'fixtures')
 
@@ -32,6 +33,7 @@ RSpec.configure do |config|
     Features::WaitForAjaxHelper,
     Features::BPFormHelper,
     Features::I18nHelper,
-    Features::FilesHelper
+    Features::FilesHelper,
+    Features::ScopesHelper
   ].each { |helper| config.include(helper, type: :feature) }
 end

--- a/spec/support/helpers/scopes_helper.rb
+++ b/spec/support/helpers/scopes_helper.rb
@@ -1,0 +1,10 @@
+module Features
+  module ScopesHelper
+    def in_group_with_label(group_label)
+      tab_selector = "//a[text() = '#{group_label}']"
+      closest_tab_panel = "ancestor::div[contains(@class, 'tab-panel') and position() = 1]"
+      group = page.find(:xpath, "#{tab_selector}/#{closest_tab_panel}")
+      yield(group)
+    end
+  end
+end


### PR DESCRIPTION
<details>
<summary>definition_raw</summary>

```
form:
  name: Test form with options
  css_class: col-xs-12 col-sm-6 col-md-5 col-lg-4
  fields:
    - name: submitSelectButtonsToBeHiddenGroup
      type: group
      label: submit_select buttons to be hidden group
      css_class: col-xs-12
      fields:
        - name: submitSelectButtonsToBeHidden
          type: submit_select
          css_class: col-xs-12
          options:
            - name: hiddenButton
              button_text: Hidden button
              label: Hidden button
              value: Hidden button
              css_class: btn btn-success btn-lg
              delete_if:
                - variable: homsOrderDataZeroVariable
                  condition: >
                    true
            - name: visibleButton
              button_text: Visible button
              label: Visible button
              value: Visible button
              css_class: btn btn-danger btn-lg
              delete_if:
                - variable: homsOrderDataZeroVariable
                  condition: >
                    false
```

</details>
<details>
<summary>Before</summary>
<img width="1158" alt="Снимок экрана 2022-01-31 в 20 01 16" src="https://user-images.githubusercontent.com/49768177/151838823-88120921-f3ae-4cf0-b817-5766c2eec5d4.png">
</details>
<details>
<summary>After</summary>
<img width="1158" alt="Снимок экрана 2022-01-31 в 20 02 40" src="https://user-images.githubusercontent.com/49768177/151838914-2886fe37-5f6c-4abd-91de-67ee683d92b8.png">
</details>