### PR TITLE
HBW-420 Fix widget CSRF failures after Rails 7.2 upgrade

### DIFF
--- a/hbw/app/controllers/hbw/base_controller.rb
+++ b/hbw/app/controllers/hbw/base_controller.rb
@@ -7,6 +7,14 @@ module HBW
 
     include Dry::Monads::Do.for(:auth_service_user)
 
+    # Requests authenticated by the Authorization header (Basic/Bearer: CRM and
+    # portal backends proxying the widget, camunda-ext task events) carry no
+    # Rails session — there is no ambient credential to forge and no session to
+    # validate a CSRF token against. Session-authenticated browser requests
+    # (widget embedded into HOMS UI) stay protected and must send X-CSRF-Token
+    # (see hbw connection.js).
+    skip_forgery_protection if: -> { request.authorization.present? }
+
     before_action :start, unless: -> { Rails.env.test? }
     before_action :set_service_user_cookie, if: -> { !Rails.env.test? && auth_as_sso_service_user? }
     before_action :get_access_token, if: -> { sso_enabled? }

--- a/hbw/app/helpers/hbw/task_helper.rb
+++ b/hbw/app/helpers/hbw/task_helper.rb
@@ -17,7 +17,7 @@ module HBW
     end
 
     def csrf_token
-      session['_csrf_token'] ||= form_authenticity_token
+      form_authenticity_token
     end
   end
 end

--- a/hbw/app/javascript/packs/hbw/connection.js
+++ b/hbw/app/javascript/packs/hbw/connection.js
@@ -30,8 +30,19 @@ export default class Connection {
 
       return fetch(url.href);
     } else {
+      // Mutating requests from a same-origin page (widget embedded into HOMS UI)
+      // are subject to Rails CSRF protection; the token comes from the layout's
+      // csrf_meta_tags. Pages of proxying integrations have no such meta tag —
+      // their backends authenticate with the Authorization header and are
+      // exempted from CSRF server-side.
+      const csrfMeta = document.querySelector('meta[name="csrf-token"]');
+
       return fetch(opts.url, {
         ...opts,
+        headers: {
+          ...(csrfMeta ? { 'X-CSRF-Token': csrfMeta.content } : {}),
+          ...opts.headers
+        },
         body: JSON.stringify({
           ...opts.data,
           payload: this.options.payload

--- a/spec/controllers/hbw/csrf_protection_spec.rb
+++ b/spec/controllers/hbw/csrf_protection_spec.rb
@@ -1,0 +1,68 @@
+require 'base64'
+
+describe 'HBW CSRF protection', type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user)   { FactoryBot.create(:user, api_token: 'api-token-123') }
+  let(:widget) { instance_double(HBW::Widget) }
+
+  let(:button_params) do
+    {bp_code:      'support_request',
+     entity_code:  '100500',
+     entity_type:  'order',
+     entity_class: 'odoo'}
+  end
+
+  around(:each) do |example|
+    ActionController::Base.allow_forgery_protection = true
+    example.run
+  ensure
+    ActionController::Base.allow_forgery_protection = false
+  end
+
+  before(:each) do
+    allow(widget).to receive(:start_bp)
+    allow(widget).to receive(:bp_buttons).and_return({buttons: [], bp_running: false})
+    allow_any_instance_of(HBW::ButtonsController).to receive(:widget).and_return(widget)
+  end
+
+  context 'with a session-authenticated browser client' do
+    before(:each) { sign_in user }
+
+    it 'rejects a mutating request without a CSRF token' do
+      post '/widget/buttons', params: button_params
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it 'accepts a mutating request with the CSRF token from the page meta tag' do
+      get root_path
+      token = Nokogiri::HTML(response.body).at('meta[name="csrf-token"]')['content']
+
+      post '/widget/buttons', params: button_params, headers: {'X-CSRF-Token' => token}
+
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  context 'with an Authorization-header client' do
+    let(:auth_headers) do
+      {'Authorization' => "Basic #{Base64.strict_encode64("#{user.email}:#{user.api_token}")}"}
+    end
+
+    it 'accepts starting a business process without a CSRF token' do
+      post '/widget/buttons', params: button_params, headers: auth_headers
+
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'accepts a file upload without a CSRF token' do
+      minio_adapter = double(save_files: [])
+      allow_any_instance_of(HBW::FilesController).to receive(:minio_adapter).and_return(minio_adapter)
+
+      post '/widget/files/upload', params: {files: [].to_json}, headers: auth_headers
+
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/javascript/connection.test.js
+++ b/spec/javascript/connection.test.js
@@ -1,0 +1,58 @@
+import Connection from 'hbw/connection';
+
+describe('Connection', () => {
+  const buildConnection = () => new Connection({
+    host:    'http://example.com',
+    path:    '/widget',
+    payload: { variables: {} }
+  });
+
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    document.head.innerHTML = '';
+  });
+
+  describe('mutating requests', () => {
+    test('sends the CSRF token from the page meta tag', () => {
+      document.head.innerHTML = '<meta name="csrf-token" content="token-from-meta">';
+
+      buildConnection().request({ url: 'http://example.com/widget/buttons', method: 'POST', data: {} });
+
+      const [, opts] = global.fetch.mock.calls[0];
+      expect(opts.headers['X-CSRF-Token']).toEqual('token-from-meta');
+    });
+
+    test('prefers a caller-provided CSRF token over the meta tag one', () => {
+      document.head.innerHTML = '<meta name="csrf-token" content="token-from-meta">';
+
+      buildConnection().request({
+        url:     'http://example.com/widget/tasks/42/form',
+        method:  'PUT',
+        data:    {},
+        headers: { 'X-CSRF-Token': 'token-from-form' }
+      });
+
+      const [, opts] = global.fetch.mock.calls[0];
+      expect(opts.headers['X-CSRF-Token']).toEqual('token-from-form');
+    });
+
+    test('sends no CSRF token when the page has no meta tag', () => {
+      buildConnection().request({ url: 'http://example.com/widget/buttons', method: 'POST', data: {} });
+
+      const [, opts] = global.fetch.mock.calls[0];
+      expect(opts.headers['X-CSRF-Token']).toBeUndefined();
+    });
+  });
+
+  describe('GET requests', () => {
+    test('passes data and payload as query parameters', () => {
+      buildConnection().request({ url: 'http://example.com/widget/buttons', method: 'GET', data: { a: '1' } });
+
+      const [url] = global.fetch.mock.calls[0];
+      expect(url).toContain('a=1');
+    });
+  });
+});


### PR DESCRIPTION
Rails 7.2 (load_defaults 7.0) enabled default forgery protection on HBW::BaseController, breaking widget POSTs. Integrations (bitrix, odoo, hupo, hccp, hoper) proxy widget requests with Basic/Bearer Authorization and no Rails session, so a session-bound CSRF token can never be valid for them, while the same-origin widget stopped sending the token when it moved from rails-ujs to fetch (HBW-265).

- Skip forgery check for Authorization-header clients: they carry no ambient credential, so CSRF does not apply; session-authenticated browser requests stay protected
- Inject X-CSRF-Token from csrf_meta_tags into all mutating widget requests (same-origin HOMS UI case); caller-provided headers win
- Fix csrf_token helper: 'session[..] ||= form_authenticity_token' overwrote the raw session token with a masked one on fresh sessions